### PR TITLE
force compile to break on missing dependency

### DIFF
--- a/Grid/algorithms/FFT.h
+++ b/Grid/algorithms/FFT.h
@@ -168,6 +168,7 @@ public:
   template<class vobj>
   void FFT_dim(Lattice<vobj> &result,const Lattice<vobj> &source,int dim, int sign){
 #ifndef HAVE_FFTW
+#error "fftw is required for FFT_dim"
     assert(0);
 #else
     conformable(result.Grid(),vgrid);


### PR DESCRIPTION
Compiling Grid for GPT is useless without fftw, because several core funtionalities of GPT require the FFT.
Note that the runtime error message of `assert 0` is beyond useless.

